### PR TITLE
terraformでGoogle Cloudにartifactを登録した

### DIFF
--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,35 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.55.0"
+  hashes = [
+    "h1:ZXZfn21OrSyT7NkVSstMH+oEnv3iE8atQqWt6LiXPxU=",
+    "zh:0a82a76dc4bbe05418075f88830f73ad3ca9d56d83a172faaf3306b016219d52",
+    "zh:367e3c0ce96ab8f9ec3e1fab5a4f9a48b3b5b336622b36b828f75bf6fb663001",
+    "zh:51fd41c7508c4c39830e5c2885bc053e90d5d24fc90462235b69394185b7fa1d",
+    "zh:7ebe62261c522631d22ab06951d0d6a1bf629b98aea5d9fe2e2e50ca256cf395",
+    "zh:9dd119eca735471d61fe9e4cc45e8c257275e2e9f4da30fba7296fc7ae8de99e",
+    "zh:a4426a0d24dcf8b3899e17530fabb3fb5791ff7db65404c26e66b031a8422bd2",
+    "zh:c1e93a786b6d014610c3f83fda12b3044009947f729b2042635fa66d9f387c47",
+    "zh:ea0703ee2f5e3732077e946cfa5cdd85119ef4ecc898a2affdeef9de9f92fe4e",
+    "zh:ecada51dd406f46e9fce7dafb0b8ef3a671b8d572dbc1d39d9fdc137029f5275",
+    "zh:effb91791080a86ff130b517bce5253aed1372ad2c6f9cfb252375a196b9f730",
+    "zh:f1885b811a31e37d53bd780d2485c19754ee2db0a66affeb5e788aa9b1950b8c",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version = "4.55.0"
+  hashes = [
+    "h1:Vo4M75l+ZMfBHXHA5763lR2v7rpqRAbk+HM9BpMoZbw=",
+    "zh:50fc733ffda7f547657cb35ffb976603dfb30ad19d64dbffb073a8609f4781fb",
+    "zh:5dc4f53eeaa9f02e331b1de85d02e2e284764cdb6824a0077c5f47f2aa556521",
+    "zh:67e3a48f6f404bfde5e50461ec4f0e23bc15912e90b56b5f620ceda3d3153fd7",
+    "zh:68a798b21ae19d09cf765b3e1ecbd496d1c34a5347b6635f032cf15577bf272f",
+    "zh:71af36f2649faa8205ada41233ed8e4e29be5cc4a8dfbbe59e5c1366ddf4acc5",
+    "zh:85d8098c7865f32a1c1f1cd50661211e6868d88af7eadce995d77b37584e6b9d",
+    "zh:979077bf607888b7b4899161d84850167c0a990acb5b1a87bfadea99f0877e87",
+    "zh:a67600720a1c75638332fc830fdd8d6f5074c0c1f92f5783434f7121a80531e0",
+    "zh:a954d1542966c9cffa2bcbe73f3f7b31dece290d68a1e488c7d1fc368dec2202",
+    "zh:b35624d14224bec658fd0bfafbf862e4a43fe51f13ab6233f85a2863fe63f8b7",
+    "zh:d6ea523ae48a3c21c7bdb8bded8b9846a90df37fcf955c15b0c8de54c61e06b4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  backend "gcs" {
+    prefix = "tfstate/v1"
+  }
+}
+
+ ## project ##
+
+provider "google" {
+  project = var.gcp_project_id
+  region = var.primary_region
+}
+
+locals {
+  backend_app_name  = "backend-app"
+  frontend_app_name = "frontend-app"
+}
+
+# Cloud Run のデプロイで利用するArtifact Registry のリポジトリ
+module "artifact-registry" {
+  source                     = "./modules/artifact-registry"
+  gcp_project_id             = var.gcp_project_id
+  artifact_registry_location = var.primary_region
+  backend_app_name           = local.backend_app_name
+  frontend_app_name          = local.frontend_app_name
+}

--- a/infra/modules/artifact-registry/artifact-registry.tf
+++ b/infra/modules/artifact-registry/artifact-registry.tf
@@ -1,0 +1,33 @@
+variable "gcp_project_id" {}
+variable "backend_app_name" {}
+variable "frontend_app_name" {}
+
+variable "artifact_registry_location" {
+  type = string
+  # https://cloud.google.com/storage/docs/locations
+  description = "Artifact Registry のロケーションをどこにするか"
+}
+
+# backendアプリケーション用の Artifact Registry リポジトリ
+resource "google_artifact_registry_repository" "backend-app" {
+  provider = google-beta
+
+  project       = var.gcp_project_id
+  location      = var.artifact_registry_location
+  repository_id = var.backend_app_name
+  description   = "バックエンドアプリケーション"
+  format        = "DOCKER"
+}
+
+
+# frontendアプリケーション用の Artifact Registry リポジトリ
+resource "google_artifact_registry_repository" "frontend-app" {
+  provider = google-beta
+
+  project       = var.gcp_project_id
+  location      = var.artifact_registry_location
+  repository_id = var.frontend_app_name
+  description   = "フロントエンドアプリケーション"
+  format        = "DOCKER"
+}
+

--- a/infra/tf.sh
+++ b/infra/tf.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+command=${@:1} 
+
+docker run -it --rm \
+  -v $PWD:/work \
+  -v $HOME/.config/gcloud:/.config/gcloud \
+  -w /work \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/.config/gcloud/application_default_credentials.json \
+  --entrypoint "/bin/sh" \
+  hashicorp/terraform:latest \
+  -c "terraform $command"

--- a/infra/variable.tf
+++ b/infra/variable.tf
@@ -1,0 +1,2 @@
+variable "gcp_project_id" {}
+variable "primary_region" {}


### PR DESCRIPTION

```jsx
$ ./tf.sh apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.artifact-registry.google_artifact_registry_repository.backend-app will be created
  + resource "google_artifact_registry_repository" "backend-app" {
      + create_time   = (known after apply)
      + description   = "バックエンドアプリケーション"
      + format        = "DOCKER"
      + id            = (known after apply)
      + location      = "us-central1"
      + name          = (known after apply)
      + project       = "nest-next-graph"
      + repository_id = "backend-app"
      + update_time   = (known after apply)
    }

  # module.artifact-registry.google_artifact_registry_repository.frontend-app will be created
  + resource "google_artifact_registry_repository" "frontend-app" {
      + create_time   = (known after apply)
      + description   = "フロントエンドアプリケーション"
      + format        = "DOCKER"
      + id            = (known after apply)
      + location      = "us-central1"
      + name          = (known after apply)
      + project       = "nest-next-graph"
      + repository_id = "frontend-app"
      + update_time   = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.artifact-registry.google_artifact_registry_repository.frontend-app: Creating...
module.artifact-registry.google_artifact_registry_repository.backend-app: Creating...
module.artifact-registry.google_artifact_registry_repository.frontend-app: Still creating... [10s elapsed]
module.artifact-registry.google_artifact_registry_repository.backend-app: Still creating... [10s elapsed]
module.artifact-registry.google_artifact_registry_repository.backend-app: Creation complete after 14s [id=projects/nest-next-graph/locations/us-central1/repositories/backend-app]
module.artifact-registry.google_artifact_registry_repository.frontend-app: Creation complete after 15s [id=projects/nest-next-graph/locations/us-central1/repositories/frontend-app]
Releasing state lock. This may take a few moments...

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```